### PR TITLE
Change project name back to DAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AML - Asset Management Library
+# DAM - DAM Asset Manager
 
 Made with :heart: by Team Bugzfeed
 

--- a/index.html
+++ b/index.html
@@ -14,11 +14,11 @@
 </head>
 
 <body>
-    <h1>Dope Asset Management Library</h1>
+    <h1>DAM Asset Manager</h1>
     <h2>Style Guide</h2>
     <br>
     <h3>Our Purpose</h3>
-        <p>The Dope Asset Management Library was inspired by an idea from the <a href="https://invenst.cse.buffalo.edu/viewideabank.php">Invenst idea bank</a>. It will have a list of items available for students and professors[Clients]. <br> They will be able to see item specifications and usage instructions. Clients will also have the option to reserve items for specified times.</p>
+        <p>DAM is a <a href="https://en.wikipedia.org/wiki/Recursive_acronym">recursive acronym</a> for DAM Asset Manager. The project's idea was inspired by an idea from the <a href="https://invenst.cse.buffalo.edu/viewideabank.php">Invenst idea bank</a>. It will have a list of items available for students and professors[Clients]. <br> They will be able to see item specifications and usage instructions. Clients will also have the option to reserve items for specified times.</p>
     <hr>
 
     <h3>Index</h3>


### PR DESCRIPTION
Per today's team meeting, this PR change the project's name back to DAM, a recursive acronym for DAM Asset Manager.

This PR supersedes #15.