### PR TITLE
Create prototype for log in page

### DIFF
--- a/prototype/log_in.html
+++ b/prototype/log_in.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Log in</title>
+  <style>
+    h1 {
+      text-align: center;
+    }
+    .btn,
+    nav {
+      background-color: #005bbb;
+    }
+    .btn:focus,
+    .btn:hover {
+      background-color: #002f56;
+    }
+    input[type=email]:not(.browser-default):focus:not([readonly]),
+    input[type=password]:not(.browser-default):focus:not([readonly]) {
+      border-bottom-color: #005bbb;
+      box-shadow: 0 1px 0 0 #005bbb;
+    }
+    input[type=email]:not(.browser-default):focus:not([readonly])+label,
+    input[type=password]:not(.browser-default):focus:not([readonly])+label {
+      color: #005bbb;
+    }
+  </style>
+</head>
+
+<body>
+  <header>
+    <nav>
+      <div class="nav-wrapper">
+        <a href="#" class="brand-logo">DAM</a>
+      </div>
+    </nav>
+  </header>
+  <main>
+    <div class="container">
+      <h1>Log in</h1>
+
+      <div class="row">
+        <form onsubmit="logIn()" class="col s12 m6 offset-m3" action="dashboard.html">
+          <div class="card-panel">
+            <div class="row">
+              <div class="input-field col s12">
+                <input type="email" id="email" required class="validate">
+                <label for="email">Email address</label>
+              </div>
+            </div>
+            <div class="row">
+              <div class="input-field col s12">
+                <input type="password" id="password" required class="validate">
+                <label for="password">Password</label>
+              </div>
+            </div>
+
+            <button class="btn waves-effect waves-light">
+              Log in
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </main>
+  
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+  <script>
+    function logIn() {
+      const email = document.getElementById('email').value;
+      alert(`Logged in as ${email}.`);
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This PR creates a prototype for the log in page (#13). After a "successful log in", the user will be sent to the dashboard page (being created in #26).

There is validation to ensure that an email address is entered, and that the password field is not empty, but that's it for now: passing those checks results in a "successful log in" for now.

![image](https://user-images.githubusercontent.com/8732346/45922668-88904080-bea0-11e8-8319-681456e61548.png)
