### PR TITLE
Create prototype for dashboard

### DIFF
--- a/prototype/dashboard.html
+++ b/prototype/dashboard.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard</title>
+  <style>
+    h1 {
+      text-align: center;
+    }
+    .btn,
+    nav {
+      background-color: #005bbb;
+    }
+    .btn:focus,
+    .btn:hover {
+      background-color: #002f56;
+    }
+    
+    .row .profile {
+      background-color: #e4e4e4;
+      margin-bottom: 1rem;
+      padding: .75rem;
+      text-align: center;
+    }
+    .profile-name {
+      font-weight: bold;
+    }
+  </style>
+</head>
+
+<body>
+  <header>
+    <nav>
+      <div class="nav-wrapper">
+        <a href="#" class="brand-logo">DAM</a>
+      </div>
+    </nav>
+  </header>
+  <main>
+    <div class="container">
+      <h1>Dashboard</h1>
+
+      <div class="row">
+        <div class="col s12 m3 profile">
+          <img
+              src="../images/sample-1.jpg"
+              alt="Sample image"
+              class="responsive-img circle"
+              onmouseover="setTimeout(() => {this.src = 'https://cse.buffalo.edu/~mhertz/MatthewPhoto.jpg'}, 500)"
+              onmouseout="setTimeout(() => {this.src = '../images/sample-1.jpg'}, 500)">
+          <div class="profile-name">Matthew Hertz</div>
+        </div>
+        <div class="col s12 m9">
+          <a class="waves-effect waves-light btn"><i class="material-icons left">call_made</i> Review reserved assets</a>
+          <a class="waves-effect waves-light btn"><i class="material-icons left">call_received</i> Acknowledge returned assets</a>
+        </div>
+      </div>
+    </div>
+  </main>
+  
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Add a prototype for a dashboard that logged in users should be able to access (#13).

Per our discussion, I've only included two "buttons" so far (the links still need to be filled in), but I'd love any feedback prototype-wise if available. Hovering over the profile image also results in the picture being changed to that of The Man - for now. The name of the user is also hard-coded to be his name - for now.

![image](https://user-images.githubusercontent.com/8732346/45922676-c8efbe80-bea0-11e8-858a-95154b28f248.png)
