### PR TITLE
Remove Python version restriction from Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,4 +9,3 @@ django = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "68309cd71a258c30a39567fce09a09ad5c4ff0bdc85b6fba22b47598c985c883"
+            "sha256": "e34336994c9a9a3f014e74492b8c604374a11b34db7a5fc7b9dcb2e1bdc5b79e"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.6"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",


### PR DESCRIPTION
As a follow-up to #39, this should allow people using different versions of Python to install packages with `pipenv` from the `Pipfile` (i.e. `pipenv install` should now work).

Realistically, we currently have support for Python 3.5+ (minimum for Django 2.1), but there is currently no way to specify a range of supported versions in `Pipfile`s (AFAIK).