### PR TITLE
Create custom manager providing item availability

### DIFF
--- a/dam/inventory/models.py
+++ b/dam/inventory/models.py
@@ -1,7 +1,24 @@
 from django.db import models
 
 
+class ItemManager(models.Manager):
+    def with_availability(self):
+        quantity = models.F('quantity')
+        reservations = models.Count(
+            'itemreservation',
+            filter=models.Q(itemreservation__is_active=True),
+        )
+        loans = models.Count(
+            'itemloan',
+            filter=models.Q(itemloan__returned_at__isnull=True),
+        )
+        available = quantity - reservations - loans
+        return super().get_queryset().annotate(available=available)
+
+
 class Item(models.Model):
     name = models.CharField(max_length=50)
     description = models.TextField()
     quantity = models.PositiveIntegerField()
+
+    objects = ItemManager()

--- a/dam/inventory/tests.py
+++ b/dam/inventory/tests.py
@@ -1,3 +1,112 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.utils import timezone
 
-# Create your tests here.
+from dam.inventory.models import Item
+from dam.loans.models import Client, ItemLoan, ItemReservation
+
+
+User = get_user_model()
+
+
+class InventoryAvailabilityTest(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.item_client = Client.objects.create()
+        cls.loan_approver = User.objects.create()
+
+        cls.test_item = Item.objects.create(
+            name='Name 1',
+            description='Description 1.',
+            quantity=10,
+        )
+
+        # Add some reservations and loans as noise to ensure that only the records
+        # for the specific item under test are taken into consideration.
+        noise_item = Item.objects.create(
+            name='Name 2',
+            description='Description 2.',
+            quantity=20,
+        )
+        ItemReservation.objects.create(
+            item=noise_item,
+            client=cls.item_client,
+            is_active=False,
+        )
+        ItemReservation.objects.create(
+            item=noise_item,
+            client=cls.item_client,
+        )
+        ItemLoan.objects.create(
+            item=noise_item,
+            client=cls.item_client,
+            approved_by=cls.loan_approver,
+        )
+        ItemLoan.objects.create(
+            item=noise_item,
+            client=cls.item_client,
+            approved_by=cls.loan_approver,
+            returned_at=timezone.now(),
+        )
+
+    def test_full_availability(self):
+        item = Item.objects.with_availability().first()
+        self.assertEqual(item.quantity, 10)
+        self.assertEqual(item.available, 10)
+
+    def test_reservation_active(self):
+        ItemReservation.objects.create(
+            item=self.test_item,
+            client=self.item_client,
+            is_active=True,
+        )
+        item = Item.objects.with_availability().first()
+        self.assertEqual(item.quantity, 10)
+        self.assertEqual(item.available, 9)
+
+    def test_reservation_inactive(self):
+        ItemReservation.objects.create(
+            item=self.test_item,
+            client=self.item_client,
+            is_active=False,
+        )
+        item = Item.objects.with_availability().first()
+        self.assertEqual(item.quantity, 10)
+        self.assertEqual(item.available, 10)
+
+    def test_loan_active(self):
+        ItemLoan.objects.create(
+            item=self.test_item,
+            client=self.item_client,
+            approved_by=self.loan_approver,
+        )
+        item = Item.objects.with_availability().first()
+        self.assertEqual(item.quantity, 10)
+        self.assertEqual(item.available, 9)
+
+    def test_loan_inactive(self):
+        ItemLoan.objects.create(
+            item=self.test_item,
+            client=self.item_client,
+            approved_by=self.loan_approver,
+            returned_at=timezone.now(),
+        )
+        item = Item.objects.with_availability().first()
+        self.assertEqual(item.quantity, 10)
+        self.assertEqual(item.available, 10)
+
+    def test_reservations_and_loans(self):
+        ItemReservation.objects.create(
+            item=self.test_item,
+            client=self.item_client,
+            is_active=True,
+        )
+        ItemLoan.objects.create(
+            item=self.test_item,
+            client=self.item_client,
+            approved_by=self.loan_approver,
+        )
+        item = Item.objects.with_availability().first()
+        self.assertEqual(item.quantity, 10)
+        self.assertEqual(item.available, 8)


### PR DESCRIPTION
Created a custom manager `ItemManager` to replace the default `Item` manager so that we can optionally annotate items with the number of that item that is available for use (i.e. `quantity - reservations - loans`) via a `with_availability` method.