### PR TITLE
Fix redirect location in test for logging in with correct credentials

### DIFF
--- a/dam/users/tests.py
+++ b/dam/users/tests.py
@@ -29,7 +29,7 @@ class LogInTest(TestCase):
             follow=True,
         )
         self.assertIn(SESSION_KEY, self.client.session)
-        self.assertRedirects(response, '/admin/')
+        self.assertRedirects(response, '/dashboard/')
 
     def test_incorrect_email(self):
         response = self.client.post('/users/log-in/', {


### PR DESCRIPTION
The test was broken in #66 since `LOGIN_REDIRECT_URL` was changed and this test wasn't updated to reflect that. This PR fixes it.