### PR TITLE
Set item name as the string representation of Item

### DIFF
--- a/dam/inventory/models.py
+++ b/dam/inventory/models.py
@@ -22,3 +22,6 @@ class Item(models.Model):
     quantity = models.PositiveIntegerField()
 
     objects = ItemManager()
+
+    def __str__(self):
+        return self.name


### PR DESCRIPTION
This makes it easier to see what items are being referenced, both in a console and in the admin.