### PR TITLE
Added titles to manager side pages and fixed grid for item details page

### DIFF
--- a/dam/core/templates/base.html
+++ b/dam/core/templates/base.html
@@ -38,7 +38,7 @@
         </div>
     {% endif %}
 
-    <main class="row container" style="margin: auto;">
+    <main class="row container" style="margin: auto; padding-top: 50px;">
         {% block body %}{% endblock %}
     </main>
 

--- a/dam/inventory/templates/inventory/details.html
+++ b/dam/inventory/templates/inventory/details.html
@@ -4,7 +4,6 @@
 {% block title %}Item Details{% endblock %}
 
 {% block body %}
-    <div class="row" style="padding-top: 50px;">
         <div class="col s12 l8">
             <div class="card">
                 <div class="carousel carousel-slider" id="demo-carousel-slider">
@@ -98,5 +97,4 @@
                 </script>
             </div>
         </div>
-    </div>
 {% endblock %}

--- a/dam/inventory/templates/inventory/details.html
+++ b/dam/inventory/templates/inventory/details.html
@@ -4,65 +4,65 @@
 {% block title %}Item Details{% endblock %}
 
 {% block body %}
-    <div class="col s6 offset-s1">
-        <div class="card">
-            <div class="carousel carousel-slider" id="demo-carousel-slider">
-                {% if item_id == 1 %}
-                    <a class="carousel-item" href="#one!"><img src={% static 'img/laptop-demo-img-1.jpg' %}></a>
-                    <a class="carousel-item" href="#two!"><img src={% static 'img/laptop-demo-img-2.jpg' %}></a>
-                    <a class="carousel-item" href="#three!"><img src={% static 'img/laptop-demo-img-3.jpg' %}></a>
-                    <a class="carousel-item" href="#four!"><img src={% static 'img/laptop-demo-img-4.jpg' %}></a>
-                {% endif %}
-                {% if item_id == 2 %}
-                    <a class="carousel-item" href="#one!"><img src={% static 'img/oculus-demo-img-1.jpg' %}></a>
-                    <a class="carousel-item" href="#two!"><img src={% static 'img/oculus-demo-img-2.jpg' %}></a>
-                    <a class="carousel-item" href="#three!"><img src={% static 'img/oculus-demo-img-3.jpg' %}></a>
-                    <a class="carousel-item" href="#four!"><img src={% static 'img/oculus-demo-img-4.jpg' %}></a>
-                {% endif %}
-                {% if item_id == 3 %}
-                    <a class="carousel-item" href="#one!"><img src={% static 'img/echo-demo-img-1.jpg' %}></a>
-                    <a class="carousel-item" href="#two!"><img src={% static 'img/echo-demo-img-2.jpg' %}></a>
-                    <a class="carousel-item" href="#three!"><img src={% static 'img/echo-demo-img-3.jpg' %}></a>
-                    <a class="carousel-item" href="#four!"><img src={% static 'img/echo-demo-img-4.jpg' %}></a>
-                {% endif %}
-                {% if item_id == 4 %}
-                    <a class="carousel-item" href="#one!"><img src={% static 'img/raspi-demo-img-1.jpg' %}></a>
-                    <a class="carousel-item" href="#two!"><img src={% static 'img/raspi-demo-img-2.jpg' %}></a>
-                    <a class="carousel-item" href="#three!"><img src={% static 'img/raspi-demo-img-3.jpg' %}></a>
-                    <a class="carousel-item" href="#four!"><img src={% static 'img/raspi-demo-img-4.jpg' %}></a>
-                {% endif %}
-                {% if item_id >= 5 %}
-                    <a class="carousel-item" href="#one!"><img src={% static 'img/placeholder.png' %}></a>
-                    <a class="carousel-item" href="#two!"><img src={% static 'img/placeholder.png' %}></a>
-                    <a class="carousel-item" href="#three!"><img src={% static 'img/placeholder.png' %}></a>
-                    <a class="carousel-item" href="#four!"><img src={% static 'img/placeholder.png' %}></a>
-                {% endif %}
-            </div>
-            <script>
-                $(document).ready(function(){
-                    $('.carousel.carousel-slider').carousel({
-                        fullWidth: true,
-                        indicators: true
-                    });
-                })
-            </script>
-            <div class="card-content">
-                <span class="card-title activator grey-text text-darken-4">{{ item_name }}</span>
-                <p>{{ item_description }}</p>
-            </div>
-        </div>
-    </div>
-    <div class="row">
-    <div class="col s4">
-        <div class="row">
-            <div class="card" style="background-color: #666666">
-                <div class="card-content white-text">
-                    <span class="card-title">Who May Borrow</span>
-                    <p>Current University at Buffalo faculty, staff and students may use their UB Card to borrow this item for a period of 2 weeks. It will be available for use at Baldy 19</p>
+    <div class="row" style="padding-top: 50px;">
+        <div class="col s12 l8">
+            <div class="card">
+                <div class="carousel carousel-slider" id="demo-carousel-slider">
+                    {% if item_id == 1 %}
+                        <a class="carousel-item" href="#one!"><img src={% static 'img/laptop-demo-img-1.jpg' %}></a>
+                        <a class="carousel-item" href="#two!"><img src={% static 'img/laptop-demo-img-2.jpg' %}></a>
+                        <a class="carousel-item" href="#three!"><img src={% static 'img/laptop-demo-img-3.jpg' %}></a>
+                        <a class="carousel-item" href="#four!"><img src={% static 'img/laptop-demo-img-4.jpg' %}></a>
+                    {% endif %}
+                    {% if item_id == 2 %}
+                        <a class="carousel-item" href="#one!"><img src={% static 'img/oculus-demo-img-1.jpg' %}></a>
+                        <a class="carousel-item" href="#two!"><img src={% static 'img/oculus-demo-img-2.jpg' %}></a>
+                        <a class="carousel-item" href="#three!"><img src={% static 'img/oculus-demo-img-3.jpg' %}></a>
+                        <a class="carousel-item" href="#four!"><img src={% static 'img/oculus-demo-img-4.jpg' %}></a>
+                    {% endif %}
+                    {% if item_id == 3 %}
+                        <a class="carousel-item" href="#one!"><img src={% static 'img/echo-demo-img-1.jpg' %}></a>
+                        <a class="carousel-item" href="#two!"><img src={% static 'img/echo-demo-img-2.jpg' %}></a>
+                        <a class="carousel-item" href="#three!"><img src={% static 'img/echo-demo-img-3.jpg' %}></a>
+                        <a class="carousel-item" href="#four!"><img src={% static 'img/echo-demo-img-4.jpg' %}></a>
+                    {% endif %}
+                    {% if item_id == 4 %}
+                        <a class="carousel-item" href="#one!"><img src={% static 'img/raspi-demo-img-1.jpg' %}></a>
+                        <a class="carousel-item" href="#two!"><img src={% static 'img/raspi-demo-img-2.jpg' %}></a>
+                        <a class="carousel-item" href="#three!"><img src={% static 'img/raspi-demo-img-3.jpg' %}></a>
+                        <a class="carousel-item" href="#four!"><img src={% static 'img/raspi-demo-img-4.jpg' %}></a>
+                    {% endif %}
+                    {% if item_id >= 5 %}
+                        <a class="carousel-item" href="#one!"><img src={% static 'img/placeholder.png' %}></a>
+                        <a class="carousel-item" href="#two!"><img src={% static 'img/placeholder.png' %}></a>
+                        <a class="carousel-item" href="#three!"><img src={% static 'img/placeholder.png' %}></a>
+                        <a class="carousel-item" href="#four!"><img src={% static 'img/placeholder.png' %}></a>
+                    {% endif %}
+                </div>
+                <script>
+                    $(document).ready(function(){
+                        $('.carousel.carousel-slider').carousel({
+                            fullWidth: true,
+                            indicators: true
+                        });
+                    })
+                </script>
+                <div class="card-content">
+                    <span class="card-title activator grey-text text-darken-4">{{ item_name }}</span>
+                    <p>{{ item_description }}</p>
                 </div>
             </div>
         </div>
-        <div class="row">
+        <div class="col s12 l4">
+            <div class="row">
+                <div class="card" style="background-color: #666666">
+                    <div class="card-content white-text">
+                        <span class="card-title">Who May Borrow</span>
+                        <p>Current University at Buffalo faculty, staff and students may use their UB Card to borrow this item for a period of 2 weeks. It will be available for use at Baldy 19</p>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
                 <ul class="collapsible" data-collapsible="expandable">
                     <li>
                         <div class="collapsible-header" style="background-color: #e4e4e4">Reserve</div>
@@ -96,7 +96,7 @@
                         $('.collapsible').collapsible({accordion: true});
                     });
                 </script>
+            </div>
         </div>
-    </div>
     </div>
 {% endblock %}

--- a/dam/loans/templates/loans/allReservations.html
+++ b/dam/loans/templates/loans/allReservations.html
@@ -18,6 +18,7 @@
                 </div>
             {% endfor %}
         {% else %}
-            <h1>No Reservations</h1>
+            <h1>Reservations</h1>
+            <h6 style="text-align: center;">No active reservations right now.</h6>
         {% endif %}
 {% endblock %}

--- a/dam/loans/templates/loans/allReservations.html
+++ b/dam/loans/templates/loans/allReservations.html
@@ -2,7 +2,6 @@
 {% block title %} Reservations {% endblock %}
 
 {% block body %}
-    <div>
         {% if reserves %}
             <h1>Reservations</h1>
             {% for reserve in reserves %}
@@ -19,7 +18,6 @@
                 </div>
             {% endfor %}
         {% else %}
-            <h1 style="text-align: center;">No Reservations</h1>
+            <h1>No Reservations</h1>
         {% endif %}
-    </div>
 {% endblock %}

--- a/dam/loans/templates/loans/allReservations.html
+++ b/dam/loans/templates/loans/allReservations.html
@@ -2,22 +2,24 @@
 {% block title %} Reservations {% endblock %}
 
 {% block body %}
-    <div style="padding-top: 50px;">
-        {% for reserve in reserves %}
-            <div class="res col s12 l6"  >
-             <div class="card" style="min-height: 20%; width: 100%">
-                  <div class="card-content">
-                    <span class="card-title" style="color:black;">{{ reserve.item.name }}</span>
-                    <p>Email: {{ reserve.client.email }}</p>
-                    <p>Name: {{ reserve.client.first_name|add:" "|add:reserve.client.last_name}}</p>
-                    <p>Reserved on: {{ reserve.reserved_at }}</p>
-                  </div>
-                  <!-- Link to product page, whole card is clickable -->
-                  <a class="link" href="{{ reserve.pk }}"></a>
-             </div>
-            </div>
-        {% empty %}
+    <div>
+        {% if reserves %}
+            <h1>Reservations</h1>
+            {% for reserve in reserves %}
+                <div class="res col s12 l6"  >
+                    <div class="card" style="min-height: 20%; width: 100%">
+                        <div class="card-content">
+                            <span class="card-title" style="color:black;">{{ reserve.item.name }}</span>
+                            <p>Email: {{ reserve.client.email }}</p>
+                            <p>Name: {{ reserve.client.first_name|add:" "|add:reserve.client.last_name}}</p>
+                            <p>Reserved on: {{ reserve.reserved_at }}</p>
+                        </div>
+                        <a class="link" href="{{ reserve.pk }}"></a>
+                    </div>
+                </div>
+            {% endfor %}
+        {% else %}
             <h1 style="text-align: center;">No Reservations</h1>
-        {% endfor %}
+        {% endif %}
     </div>
 {% endblock %}

--- a/dam/loans/templates/loans/allReturns.html
+++ b/dam/loans/templates/loans/allReturns.html
@@ -20,6 +20,6 @@
             {% endfor %}
         {% else %}
             <h1>Loans</h1>
-            <h1>No Loans</h1>
+            <h6 style="text-align: center;">No active loans right now.</h6>
         {% endif %}
 {% endblock %}

--- a/dam/loans/templates/loans/allReturns.html
+++ b/dam/loans/templates/loans/allReturns.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Returns{% endblock %}
 {% block body %}
-    <div>
         {% if returns %}
             <h1>Loans</h1>
             {% for loan in returns %}
@@ -20,7 +19,7 @@
                 </div>
             {% endfor %}
         {% else %}
-            <h1 style="text-align: center;">No Loans</h1>
+            <h1>Loans</h1>
+            <h1>No Loans</h1>
         {% endif %}
-    </div>
 {% endblock %}

--- a/dam/loans/templates/loans/allReturns.html
+++ b/dam/loans/templates/loans/allReturns.html
@@ -1,24 +1,26 @@
 {% extends 'base.html' %}
 {% block title %}Returns{% endblock %}
 {% block body %}
-    <div style="padding-top: 50px;">
-        {% for loan in returns %}
-            <div class="res col s12 l6"  >
-             <div class="card" style="min-height: 20%; width: 100%">
-                  <div class="card-content">
-                    <span class="card-title" style="color:black;">{{ loan.item.name }}</span>
-                    <p>Email: {{ loan.client.email }}</p>
-                    <p>Name: {{ loan.client.first_name|add:" "|add:loan.client.last_name}}</p>
-                    <p>Reserved at: {{ loan.reserved_at }}</p>
-                    <p>Approved by: {{ loan.approved_by }}</p>
-                    <p>Approved at: {{ loan.approved_at }}</p>
-                  </div>
-                  <!-- Link to product page, whole card is clickable -->
-                  <a class="link" href="{{ loan.pk }}"></a>
-             </div>
-            </div>
-        {% empty %}
+    <div>
+        {% if returns %}
+            <h1>Loans</h1>
+            {% for loan in returns %}
+                <div class="res col s12 l6"  >
+                    <div class="card" style="min-height: 20%; width: 100%">
+                        <div class="card-content">
+                            <span class="card-title" style="color:black;">{{ loan.item.name }}</span>
+                            <p>Email: {{ loan.client.email }}</p>
+                            <p>Name: {{ loan.client.first_name|add:" "|add:loan.client.last_name}}</p>
+                            <p>Reserved at: {{ loan.reserved_at }}</p>
+                            <p>Approved by: {{ loan.approved_by }}</p>
+                            <p>Approved at: {{ loan.approved_at }}</p>
+                        </div>
+                        <a class="link" href="{{ loan.pk }}"></a>
+                    </div>
+                </div>
+            {% endfor %}
+        {% else %}
             <h1 style="text-align: center;">No Loans</h1>
-        {% endfor %}
+        {% endif %}
     </div>
 {% endblock %}

--- a/dam/loans/templates/loans/loanItem.html
+++ b/dam/loans/templates/loans/loanItem.html
@@ -5,7 +5,6 @@
 
 {% block body %}
 
-    <div class="row" style="padding-top: 50px;">
         <div class="col s12 l8">
             <div class="card">
                 <div class="card-image"
@@ -51,5 +50,4 @@
 
             </div>
         </form>
-    </div>
 {% endblock %}

--- a/dam/loans/templates/loans/returnItem.html
+++ b/dam/loans/templates/loans/returnItem.html
@@ -4,9 +4,7 @@
 {% block title %} Return Item {% endblock %}
 
 {% block body %}
-
-    <div class="row" style="padding-top: 50px;">
-        <div class="col s12 l8">
+     <div class="col s12 l8">
             <div class="card">
                 <div class="card-image"
                      style="background-image:url({% static 'img/placeholder.png' %});background-size:80%;background-repeat: no-repeat;background-position:center;">
@@ -17,7 +15,6 @@
                 </div>
             </div>
         </div>
-
         <form method="post" class="col s12 l4">
             {% csrf_token %}
             <div class="row">
@@ -51,5 +48,4 @@
                 </div>
             </div>
         </form>
-    </div>
 {% endblock %}


### PR DESCRIPTION
**Finishing up for the Demo:**
- Added the titles "Reservations" and "Loans" to manager side pages. 
- Modified for loops to if statements so the "Reservations" title changes to "No Reservations" when empty (same with Loans). 
- Modified the grid layout for item details page to add padding on top and making it more responsive

*Loans page with active Loans*
<img width="1006" alt="screen shot 2018-10-28 at 5 54 17 pm" src="https://user-images.githubusercontent.com/15279043/47622408-1e8c3c00-dadb-11e8-94fb-efbf56af5abb.png">
*Loans page with no active Loans*
<img width="1029" alt="screen shot 2018-10-28 at 5 54 31 pm" src="https://user-images.githubusercontent.com/15279043/47622407-1e8c3c00-dadb-11e8-9158-b7a6375c185e.png">
##
*Item Details page on desktop*
<img width="1031" alt="screen shot 2018-10-28 at 5 53 25 pm" src="https://user-images.githubusercontent.com/15279043/47622410-1f24d280-dadb-11e8-8b3b-7dc8a3e3b64b.png">
*Item Details page on mobile*
<img width="405" alt="screen shot 2018-10-28 at 5 53 50 pm" src="https://user-images.githubusercontent.com/15279043/47622409-1e8c3c00-dadb-11e8-9515-75b1ac6a7500.png">



