### PR TITLE
Update background color of success and error messages

### DIFF
--- a/dam/core/templates/base.html
+++ b/dam/core/templates/base.html
@@ -33,7 +33,9 @@
     {% if messages %}
         <div class="container">
             {% for message in messages %}
-                <p class="notification">{{ message }}</p>
+                <p class="notification{% if message.tags %} {{ message.tags }}{% endif %}">
+                    {{ message }}
+                </p>
             {% endfor %}
         </div>
     {% endif %}

--- a/dam/users/templates/users/log_in.html
+++ b/dam/users/templates/users/log_in.html
@@ -10,7 +10,7 @@
             {% csrf_token %}
 
             {% if form.errors %}
-                <div class="notification" style="background-color: #900; margin-bottom: 1rem;">
+                <div class="notification error">
                     {{ form.non_field_errors|join:' ' }}
                 </div>
             {% endif %}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -109,6 +109,12 @@ footer {
     border-radius: 2px;
     color: var(--white);
     padding: 1rem;
-    margin-top: 1rem;
+    margin-bottom: 1rem;
     text-align: center;
+}
+.notification.error {
+    background-color: var(--red);
+}
+.notification.success {
+    background-color: var(--green);
 }


### PR DESCRIPTION
#101:
- Success messages now have a green background
- Error messages now have a red background
- All other messages will continue to use the default blue background