### PR TITLE
Fixed Overlap in Details Card and Reserve Dropdown

### DIFF
--- a/dam/inventory/templates/inventory/details.html
+++ b/dam/inventory/templates/inventory/details.html
@@ -4,7 +4,7 @@
 {% block title %}Item Details{% endblock %}
 {% block style %}
 <style>
-    @media only screen and (max-width: 768px) {
+    @media only screen and (max-width: 992px) {
         #cardprofile {
             padding-left: 0;
             padding-right: 0;
@@ -74,7 +74,6 @@
 
                 </div>
             </div>
-            <div class="row">
                 <ul class="collapsible" data-collapsible="expandable">
                     <li>
 
@@ -112,7 +111,5 @@
                 </script>
             </div>
         </div>
-
-    </div>
 
 {% endblock %}


### PR DESCRIPTION
Removed a row to prevent overlapping.
Also set the media query to kick in when screen width is 992 px for the details card to be the same width as everything else.