### PR TITLE
Add indirection to access Client's name and email address

### DIFF
--- a/dam/loans/models.py
+++ b/dam/loans/models.py
@@ -8,6 +8,12 @@ class Client(models.Model):
     first_name = models.CharField(max_length=50)
     last_name = models.CharField(max_length=50)
 
+    def get_email_address(self):
+        return self.email
+
+    def get_full_name(self):
+        return '{} {}'.format(self.first_name, self.last_name)
+
 
 class ItemReservation(models.Model):
     item = models.ForeignKey('inventory.Item', models.CASCADE)

--- a/dam/loans/templates/loans/allReservations.html
+++ b/dam/loans/templates/loans/allReservations.html
@@ -2,23 +2,21 @@
 {% block title %} Reservations {% endblock %}
 
 {% block body %}
-        {% if reserves %}
-            <h1>Reservations</h1>
-            {% for reserve in reserves %}
-                <div class="res col s12 l6"  >
-                    <div class="card" style="min-height: 20%; width: 100%">
-                        <div class="card-content">
-                            <span class="card-title" style="color:black;">{{ reserve.item.name }}</span>
-                            <p>Email: {{ reserve.client.email }}</p>
-                            <p>Name: {{ reserve.client.first_name|add:" "|add:reserve.client.last_name}}</p>
-                            <p>Reserved on: {{ reserve.reserved_at }}</p>
-                        </div>
-                        <a class="link" href="{{ reserve.pk }}"></a>
-                    </div>
+    <h1>Reservations</h1>
+
+    {% for reserve in reserves %}
+        <div class="res col s12 l6"  >
+            <div class="card" style="min-height: 20%; width: 100%">
+                <div class="card-content">
+                    <span class="card-title" style="color:black;">{{ reserve.item.name }}</span>
+                    <p>Email: {{ reserve.client.email }}</p>
+                    <p>Name: {{ reserve.client.first_name|add:" "|add:reserve.client.last_name }}</p>
+                    <p>Reserved on: {{ reserve.reserved_at }}</p>
                 </div>
-            {% endfor %}
-        {% else %}
-            <h1>Reservations</h1>
-            <h6 style="text-align: center;">No active reservations right now.</h6>
-        {% endif %}
+                <a class="link" href="{{ reserve.pk }}"></a>
+            </div>
+        </div>
+    {% empty %}
+        <h6 style="text-align: center;">No active reservations right now.</h6>
+    {% endfor %}
 {% endblock %}

--- a/dam/loans/templates/loans/allReservations.html
+++ b/dam/loans/templates/loans/allReservations.html
@@ -9,8 +9,8 @@
             <div class="card" style="min-height: 20%; width: 100%">
                 <div class="card-content">
                     <span class="card-title" style="color:black;">{{ reserve.item.name }}</span>
-                    <p>Email: {{ reserve.client.email }}</p>
-                    <p>Name: {{ reserve.client.first_name|add:" "|add:reserve.client.last_name }}</p>
+                    <p>Email: {{ reserve.client.get_email_address }}</p>
+                    <p>Name: {{ reserve.client.get_full_name }}</p>
                     <p>Reserved on: {{ reserve.reserved_at }}</p>
                 </div>
                 <a class="link" href="{{ reserve.pk }}"></a>

--- a/dam/loans/templates/loans/allReturns.html
+++ b/dam/loans/templates/loans/allReturns.html
@@ -8,8 +8,8 @@
             <div class="card" style="min-height: 20%; width: 100%">
                 <div class="card-content">
                     <span class="card-title" style="color:black;">{{ loan.item.name }}</span>
-                    <p>Email: {{ loan.client.email }}</p>
-                    <p>Name: {{ loan.client.first_name|add:" "|add:loan.client.last_name }}</p>
+                    <p>Email: {{ loan.client.get_email_address }}</p>
+                    <p>Name: {{ loan.client.get_full_name }}</p>
                     <p>Reserved at: {{ loan.reserved_at }}</p>
                     <p>Approved by: {{ loan.approved_by }}</p>
                     <p>Approved at: {{ loan.approved_at }}</p>

--- a/dam/loans/templates/loans/allReturns.html
+++ b/dam/loans/templates/loans/allReturns.html
@@ -1,25 +1,23 @@
 {% extends 'base.html' %}
 {% block title %}Returns{% endblock %}
 {% block body %}
-        {% if returns %}
-            <h1>Loans</h1>
-            {% for loan in returns %}
-                <div class="res col s12 l6"  >
-                    <div class="card" style="min-height: 20%; width: 100%">
-                        <div class="card-content">
-                            <span class="card-title" style="color:black;">{{ loan.item.name }}</span>
-                            <p>Email: {{ loan.client.email }}</p>
-                            <p>Name: {{ loan.client.first_name|add:" "|add:loan.client.last_name}}</p>
-                            <p>Reserved at: {{ loan.reserved_at }}</p>
-                            <p>Approved by: {{ loan.approved_by }}</p>
-                            <p>Approved at: {{ loan.approved_at }}</p>
-                        </div>
-                        <a class="link" href="{{ loan.pk }}"></a>
-                    </div>
+    <h1>Loans</h1>
+
+    {% for loan in returns %}
+        <div class="res col s12 l6"  >
+            <div class="card" style="min-height: 20%; width: 100%">
+                <div class="card-content">
+                    <span class="card-title" style="color:black;">{{ loan.item.name }}</span>
+                    <p>Email: {{ loan.client.email }}</p>
+                    <p>Name: {{ loan.client.first_name|add:" "|add:loan.client.last_name }}</p>
+                    <p>Reserved at: {{ loan.reserved_at }}</p>
+                    <p>Approved by: {{ loan.approved_by }}</p>
+                    <p>Approved at: {{ loan.approved_at }}</p>
                 </div>
-            {% endfor %}
-        {% else %}
-            <h1>Loans</h1>
-            <h6 style="text-align: center;">No active loans right now.</h6>
-        {% endif %}
+                <a class="link" href="{{ loan.pk }}"></a>
+            </div>
+        </div>
+    {% empty %}
+        <h6 style="text-align: center;">No active loans right now.</h6>
+    {% endfor %}
 {% endblock %}

--- a/dam/loans/templates/loans/loanItem.html
+++ b/dam/loans/templates/loans/loanItem.html
@@ -27,11 +27,11 @@
                         <hr>
                         <br>
                         <p>Client Name:</p>
-                        <p>{{ reserved.client.first_name }} {{ reserved.client.last_name }}</p>
+                        <p>{{ reserved.client.get_full_name }}</p>
                         <hr>
                         <br>
                         <p>Email: </p>
-                        <p>{{ reserved.client.email }}</p>
+                        <p>{{ reserved.client.get_email_address }}</p>
                         <hr>
                         <br>
                         <p>Reserved on: </p>

--- a/dam/loans/templates/loans/returnItem.html
+++ b/dam/loans/templates/loans/returnItem.html
@@ -25,10 +25,10 @@
                         <hr>
                         <br>
                         <p>Client Name:</p>
-                        <p>{{ loan.client.first_name }} {{ loan.client.last_name }}</p>
+                        <p>{{ loan.client.get_full_name }}</p>
                         <br>
                         <p>Email: </p>
-                        <p>{{ loan.client.email }}</p>
+                        <p>{{ loan.client.get_email_address }}</p>
                         <br>
                         <p>Item Name:</p>
                         <p>{{ loan.item.name }}</p>

--- a/dam/loans/tests.py
+++ b/dam/loans/tests.py
@@ -96,3 +96,21 @@ class ValidateTestCases(TestCase):
         response= self.client.post('/loans/reserve/3')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['id'],'-2')
+
+
+class ClientTest(TestCase):
+    def test_get_email_address(self):
+        client = Client.objects.create(
+            first_name='First',
+            last_name='Last',
+            email='first.last@example.com',
+        )
+        self.assertEqual(client.get_email_address(), 'first.last@example.com')
+
+    def test_get_full_name(self):
+        client = Client.objects.create(
+            first_name='First',
+            last_name='Last',
+            email='first.last@example.com',
+        )
+        self.assertEqual(client.get_full_name(), 'First Last')


### PR DESCRIPTION
Fixes #145.

I went ahead with getters since it hopefully makes it more obvious that those are what should be used. Properties would look a bit cleaner (e.g. `client.full_name` is awesome), but might make it less clear about where to access/store data (particularly for email addresses):
- Having `client.email` and `client.email_address` would be confusing
- Having `client._email` and `client.email` might be fine, but if we allow assignment to `client.email` to work "as expected" then we'd probably also want to maintain that for first and last name _or_ make them "private"/internal-only (which could be a good thing)

I'm curious to hear if anyone has opinions on which method you'd prefer: let me know if you need any clarification.