### PR TITLE
Conditionally show links on dashboard (based on access)

### DIFF
--- a/dam/dashboard/templates/dashboard/dashboard.html
+++ b/dam/dashboard/templates/dashboard/dashboard.html
@@ -54,11 +54,13 @@
                     <span class="card-title">{{ user.get_full_name }}</span>
                 </div>
 
+                {% if user.is_staff %}
                 <div class="card-action dashboard-links">
-                    <a href="{% url 'loans:allres' %}">Reserve Item List</a>
-                    <a href="{% url 'loans:allrets' %}">Return Item List</a>
-                    <a href="{% url 'admin:inventory_item_changelist' %}">Add/Remove Item</a>
+                    {% if perms.loans.view_itemreservation %}<a href="{% url 'loans:allres' %}">Reserve Item List</a>{% endif %}
+                    {% if perms.loans.view_itemloan %}<a href="{% url 'loans:allrets' %}">Return Item List</a>{% endif %}
+                    {% if perms.inventory.add_item %}<a href="{% url 'admin:inventory_item_changelist' %}">Add/Remove Item</a>{% endif %}
                 </div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/dam/dashboard/tests.py
+++ b/dam/dashboard/tests.py
@@ -14,3 +14,9 @@ class DashboardTest(TestCase):
     def test_page_login_required(self):
         response = self.client.get('/dashboard/')
         self.assertRedirects(response, '/users/log-in/?next=/dashboard/')
+
+    def test_authenticated_can_access(self):
+        self.client.login('test@example.com', 'password')
+        response = self.client.get('/dashboard/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Dashboard')

--- a/dam/dashboard/tests.py
+++ b/dam/dashboard/tests.py
@@ -13,4 +13,4 @@ class DashboardTest(TestCase):
 
     def test_page_login_required(self):
         response = self.client.get('/dashboard/')
-        self.assertEquals(response.status_code, 302)
+        self.assertRedirects(response, '/users/log-in/?next=/dashboard/')

--- a/dam/dashboard/tests.py
+++ b/dam/dashboard/tests.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
 from dam.users.models import User
 
-class dashboardTest(TestCase):
+
+class DashboardTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         User.objects.create_user(
@@ -13,16 +14,3 @@ class dashboardTest(TestCase):
     def test_page_login_required(self):
         response = self.client.get('/dashboard/')
         self.assertEquals(response.status_code, 302)
-
-    def test_correct_login_redirect(self):
-        self.client.post(
-            '/users/log-in/',
-            {
-                'email': 'test@example.com',
-                'password': 'password',
-            },
-            follow=True,
-        )
-        response = self.client.get('/dashboard/')
-        self.assertEquals(response.status_code, 200)
-        self.assertContains(response, 'Dashboard')


### PR DESCRIPTION
Only show links to pages that users should have access to on the dashboard, as part of #153