### PR TITLE
Fix counting of available items

### DIFF
--- a/dam/inventory/models.py
+++ b/dam/inventory/models.py
@@ -6,10 +6,12 @@ class ItemManager(models.Manager):
         quantity = models.F('quantity')
         reservations = models.Count(
             'itemreservation',
+            distinct=True,
             filter=models.Q(itemreservation__is_active=True),
         )
         loans = models.Count(
             'itemloan',
+            distinct=True,
             filter=models.Q(itemloan__returned_at__isnull=True),
         )
         available = quantity - reservations - loans


### PR DESCRIPTION
Only count distinct reservations and loans when determining the number of available items.

Fixes #186